### PR TITLE
chore: zoneless support

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,6 @@ example.com.      NS
     read_timeout TIME_MS
     ttl TIME_S
     prefix PREFIX
-    suffix SUFFIX
   }
 }
 ```
@@ -52,7 +51,6 @@ example.com.      NS
 - `read_timeout` maximum time to wait for the redis backend to respond (in ms, optional)
 - `ttl` default ttl for dns records which have no ttl set (in seconds, default 3600)
 - `prefix` a prefix added to all redis keys
-- `suffix` a suffix added to all redis keys
 
 ### example
 
@@ -68,7 +66,6 @@ corefile:
       read_timeout 2000
       ttl 300
       prefix DNS_
-      suffix _DNS
     }
   }
 }

--- a/plugin/setup.go
+++ b/plugin/setup.go
@@ -25,8 +25,6 @@ func setup(c *caddy.Controller) error {
 	}
 
 	p := &Plugin{Redis: r}
-	p.loadCache()
-
 	dnsserver.GetConfig(c).AddPlugin(func(next plugin.Handler) plugin.Handler {
 		p.Next = next
 		return p
@@ -39,46 +37,41 @@ func redisParse(c *caddy.Controller) (*redis.Redis, error) {
 
 	if c.Next() {
 		if c.Val() != "redis" {
-			return redis.New(), c.ArgErr()
+			return nil, c.ArgErr()
 		}
 		if !c.NextArg() {
-			return redis.New(), c.ArgErr()
+			return nil, c.ArgErr()
 		}
-		log.Infof("redis: configure Redis support for domain '%s'", c.Val())
+		log.Infof("redis: configured Redis support for domain '%s'", c.Val())
 
-		r := redis.New()
+		r := redis.New(c.Val())
 		if c.NextBlock() {
 			for {
 				switch c.Val() {
 				case "address":
 					if !c.NextArg() {
-						return redis.New(), c.ArgErr()
+						return nil, c.ArgErr()
 					}
 					r.SetAddress(c.Val())
 
 				case "username":
 					if !c.NextArg() {
-						return redis.New(), c.ArgErr()
+						return nil, c.ArgErr()
 					}
 					r.SetUsername(c.Val())
 				case "password":
 					if !c.NextArg() {
-						return redis.New(), c.ArgErr()
+						return nil, c.ArgErr()
 					}
 					r.SetPassword(c.Val())
 				case "prefix":
 					if !c.NextArg() {
-						return redis.New(), c.ArgErr()
+						return nil, c.ArgErr()
 					}
 					r.SetKeyPrefix(c.Val())
-				case "suffix":
-					if !c.NextArg() {
-						return redis.New(), c.ArgErr()
-					}
-					r.SetKeySuffix(c.Val())
 				case "connect_timeout":
 					if !c.NextArg() {
-						return redis.New(), c.ArgErr()
+						return nil, c.ArgErr()
 					}
 					t, err := strconv.Atoi(c.Val())
 					if err == nil {
@@ -86,7 +79,7 @@ func redisParse(c *caddy.Controller) (*redis.Redis, error) {
 					}
 				case "read_timeout":
 					if !c.NextArg() {
-						return redis.New(), c.ArgErr()
+						return nil, c.ArgErr()
 					}
 					t, err := strconv.Atoi(c.Val())
 					if err != nil {
@@ -94,7 +87,7 @@ func redisParse(c *caddy.Controller) (*redis.Redis, error) {
 					}
 				default:
 					if c.Val() != "}" {
-						return redis.New(), c.Errf("unknown property '%s'", c.Val())
+						return nil, c.Errf("unknown property '%s'", c.Val())
 					}
 				}
 


### PR DESCRIPTION
Remove all logic specific to taking into account the zone name for
a given DNS query, since the Redis backend stores FQDNs. Instead just
keep track of the zone name configured in the Redis stanza in the
CoreDNS configuration file.
